### PR TITLE
Updated .vimrc tex compilation macro to generalize file name

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -34,8 +34,8 @@ let mapleader=";"
 """LATEX COMMANDS"""
 	"NORMAL MODE MACROS"
 	
-	"compile script must be in same directory as main.tex"
-	autocmd Filetype tex nnoremap;cc :! ./compiletex.sh main 1 <Enter>
+	"compile script must be in same directory as %.tex"
+	autocmd Filetype tex nnoremap;cc :! ./compiletex.sh % 1 <Enter>
 
 	"INSERT MODE MACROS"
 	"Equation and listing environments"


### PR DESCRIPTION
Just made a small change to make the name of the file whatever the current file name is instead of limiting it to main.tex